### PR TITLE
localStorage에서 관리하던 로그인 정보 앱 라이프사이클동안 zustand store에서 관리하도록 변경

### DIFF
--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,0 +1,24 @@
+import { HttpResponse, http } from 'msw';
+
+export const authHandlers = [
+  http.get('/auth/kakao', () => {
+    console.log('authHandler Working...');
+    return HttpResponse.json(
+      {
+        accessToken:
+          'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjk4NTA1NzM2LCJleHAiOjE2OTg1MDU4NTZ9.E0p1V4PiBDmZIZqglGjQFWh-bgbA7n7qryYnOZ3cxMuaBvp-ejkXC2b-bA5kDjZrlzyyiWuTwe-sbYk73tIR0w',
+        refreshToken:
+          'eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2OTg1MDU3MzYsImV4cCI6MTY5ODUwNjczNn0.GIybXCnow3xx7B6phYfSqvpVV2GB9ieos7t-ciGSCEJMIZqeEk9DcJcLsfHNUISTf4-xWTtnZ7_OVR9WAm3AfA',
+        id: 1,
+        nickname: '창현',
+        profileImageUrl: 'https://picsum.photos/200',
+        email: 'changhyeon.h@kakao.com',
+        oauthId: 32014123,
+        oauthProvider: 'KAKAO',
+        addressDepth1: '서울시',
+        addressDepth2: '영등포구',
+      },
+      { status: 200 }
+    );
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
 import { testHandlers } from './apiTest';
+import { authHandlers } from './auth';
 import { crewHandlers } from './crew';
 import { gameHandlers } from './game';
 import { memberHandlers } from './member';
@@ -6,6 +7,7 @@ import { otherHandlers } from './other';
 import { rankingHandlers } from './ranking';
 
 export const handlers = [
+  ...authHandlers,
   ...testHandlers,
   ...gameHandlers,
   ...crewHandlers,

--- a/src/stores/accessToken.store.ts
+++ b/src/stores/accessToken.store.ts
@@ -1,19 +1,11 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 interface AccessTokenState {
   accessToken: string | null;
   setAccessToken: (accessToken: string | null) => void;
 }
 
-export const useTokenStore = create(
-  persist<AccessTokenState>(
-    (set) => ({
-      accessToken: null,
-      setAccessToken: (accessToken) => set({ accessToken }),
-    }),
-    {
-      name: 'ACCESS_TOKEN_PERSIST',
-    }
-  )
-);
+export const useTokenStore = create<AccessTokenState>((set) => ({
+  accessToken: null,
+  setAccessToken: (accessToken) => set({ accessToken }),
+}));

--- a/src/stores/loginInfo.store.ts
+++ b/src/stores/loginInfo.store.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 import { Authenticated, Registration } from '@type/models';
 
@@ -9,14 +8,7 @@ type LoginInfoState = {
   setLoginInfo: (loginInfo: LoginInfo | null) => void;
 };
 
-export const useLoginInfoStore = create(
-  persist<LoginInfoState>(
-    (set) => ({
-      loginInfo: null,
-      setLoginInfo: (loginInfo) => set({ loginInfo }),
-    }),
-    {
-      name: 'LOGIN_INFO_PERSIST',
-    }
-  )
-);
+export const useLoginInfoStore = create<LoginInfoState>((set) => ({
+  loginInfo: null,
+  setLoginInfo: (loginInfo) => set({ loginInfo }),
+}));


### PR DESCRIPTION
로그인 과정을 디버깅 하기 위해 변경했고, 추후 필요시 다시 로컬에서 관리하거나 하는 식으로 변경 예정

[feat: zustand persist 제거](https://github.com/1eecan/pickple-front-refactoring/commit/6268dd59107127b1726d48346a0614cf44729e7a) 


[feat: 개발용 auth handlers 추가](https://github.com/1eecan/pickple-front-refactoring/commit/8566db8df24bb4de89e7545e5116e595e6ac5f77)