### PR TITLE
MainPage 추상화

### DIFF
--- a/src/pages/MainPage/MainPage.style.ts
+++ b/src/pages/MainPage/MainPage.style.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { theme } from '@styles/theme';
+
 export const MainPageContainer = styled.div`
   width: 100%;
   margin-top: 0.6rem;
@@ -15,3 +17,25 @@ export const MainPageSubContainer = styled.div`
   gap: 10px;
   margin-bottom: 1.25rem;
 `;
+
+export const MAIN_PAGE_BUTTON_PROP = {
+  width: '100%',
+  height: '2.5rem',
+  fontSize: `${theme.FONT_SIZE.MD}`,
+  fontWeight: theme.FONT_WEIGHT.BOLD,
+  lineHeight: 0,
+  textColor: `${theme.PALETTE.RED_400}`,
+  borderColor: `${theme.PALETTE.RED_400}`,
+  backgroundColor: 'white',
+};
+
+export type MAIN_PAGE_BUTTON_PROP_TYPE = {
+  width: string;
+  height: string;
+  fontSize: string;
+  fontWeight: number;
+  lineHeight: number;
+  textColor: string;
+  borderColor: string;
+  backgroundColor: string;
+};

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,8 +1,6 @@
 import { Header } from '@components/Header';
 
-import { theme } from '@styles/theme';
-
-import { MainPageContainer } from './MainPage.style';
+import { MAIN_PAGE_BUTTON_PROP, MainPageContainer } from './MainPage.style';
 import CrewRanking from './components/CrewRanking';
 import NearGame from './components/NearGame';
 import RecommendCrew from './components/RecommendCrew';
@@ -31,15 +29,4 @@ export const MainPage = () => {
       <RecommendCrew {...recommendCrewProps} />
     </MainPageContainer>
   );
-};
-
-const MAIN_PAGE_BUTTON_PROP = {
-  width: '100%',
-  height: '2.5rem',
-  fontSize: `${theme.FONT_SIZE.MD}`,
-  fontWeight: theme.FONT_WEIGHT.BOLD,
-  lineHeight: 0,
-  textColor: `${theme.PALETTE.RED_400}`,
-  borderColor: `${theme.PALETTE.RED_400}`,
-  backgroundColor: 'white',
 };

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,105 +1,34 @@
-import { RankingHeader } from '@pages/CrewsRankingPage/CrewsRankingPage.styles';
-import { RankingItem } from '@pages/CrewsRankingPage/components/RankingItem';
-
 import { Header } from '@components/Header';
-import { Button } from '@components/shared/Button';
-import { Flex } from '@components/shared/Flex';
-import { Text } from '@components/shared/Text';
 
 import { theme } from '@styles/theme';
 
-import { PATH_NAME } from '@constants/pathName';
-
-import { MainPageContainer, MainPageSubContainer } from './MainPage.style';
-import { MainPageNoContentItem } from './components/MainPageNoContentItem';
+import { MainPageContainer } from './MainPage.style';
+import CrewRanking from './components/CrewRanking';
+import NearGame from './components/NearGame';
+import RecommendCrew from './components/RecommendCrew';
 import { useMainPage } from './hooks/useMainPage';
 
 export const MainPage = () => {
   const { navigate, slicedCrewsRanking, filteredGameData, filteredCrewData } =
     useMainPage();
 
+  const nearGameProps = { filteredGameData, navigate, MAIN_PAGE_BUTTON_PROP };
+  const crewRankingProps = {
+    slicedCrewsRanking,
+    navigate,
+    MAIN_PAGE_BUTTON_PROP,
+  };
+  const recommendCrewProps = {
+    filteredCrewData,
+    navigate,
+    MAIN_PAGE_BUTTON_PROP,
+  };
   return (
     <MainPageContainer>
       <Header isLogo={true} />
-      <MainPageSubContainer>
-        <Text children={'내 근처 게스트 매치'} weight={700} size={'1.25rem'} />
-        {filteredGameData.length === 0 ? (
-          <MainPageNoContentItem
-            name={'GAME'}
-            onClick={() => navigate(PATH_NAME.CREATE_GAME)}
-          />
-        ) : (
-          filteredGameData
-        )}
-        {filteredGameData.length === 0 || filteredGameData.length === 1 ? (
-          <Button
-            {...MAIN_PAGE_BUTTON_PROP}
-            onClick={() => navigate(PATH_NAME.MAP)}
-          >
-            다른 지역 게스트 매치 보러가기
-          </Button>
-        ) : (
-          <Button
-            {...MAIN_PAGE_BUTTON_PROP}
-            onClick={() => navigate(PATH_NAME.GAMES_NEAR)}
-          >
-            더보기
-          </Button>
-        )}
-      </MainPageSubContainer>
-      <MainPageSubContainer>
-        <Text children={'크루 랭킹'} weight={700} size={'1.25rem'} />
-        <RankingHeader justify="space-between">
-          <Flex gap={55}>
-            <Text size={14} nowrap>
-              순위
-            </Text>
-            <Text size={14} nowrap>
-              크루 이름
-            </Text>
-          </Flex>
-          <Text size={14} nowrap>
-            점수
-          </Text>
-        </RankingHeader>
-        {slicedCrewsRanking.map((crewRank) => (
-          <RankingItem
-            key={crewRank.id}
-            rank={crewRank.rank}
-            name={crewRank.name}
-            profileImageUrl={crewRank.profileImageUrl}
-            rating={crewRank.totalScore}
-            onClick={() =>
-              navigate(PATH_NAME.GET_CREWS_PATH(String(crewRank.id)))
-            }
-          />
-        ))}
-        <Button
-          {...MAIN_PAGE_BUTTON_PROP}
-          onClick={() => navigate(PATH_NAME.CREWS_RANKING)}
-        >
-          전체 크루 랭킹 보기
-        </Button>
-      </MainPageSubContainer>
-      <MainPageSubContainer>
-        <Text children={'추천 크루'} weight={700} size={'1.25rem'} />
-        {filteredCrewData.length === 0 ? (
-          <MainPageNoContentItem
-            name={'CREW'}
-            onClick={() => navigate(PATH_NAME.CREATE_CREW)}
-          />
-        ) : (
-          filteredCrewData
-        )}
-        {filteredCrewData.length !== 0 && (
-          <Button
-            {...MAIN_PAGE_BUTTON_PROP}
-            onClick={() => navigate(PATH_NAME.CREWS_RECOMMEND)}
-          >
-            더보기
-          </Button>
-        )}
-      </MainPageSubContainer>
+      <NearGame {...nearGameProps} />
+      <CrewRanking {...crewRankingProps} />
+      <RecommendCrew {...recommendCrewProps} />
     </MainPageContainer>
   );
 };

--- a/src/pages/MainPage/components/CrewRanking.tsx
+++ b/src/pages/MainPage/components/CrewRanking.tsx
@@ -1,0 +1,55 @@
+import { RankingHeader } from '@pages/CrewsRankingPage/CrewsRankingPage.styles';
+import { RankingItem } from '@pages/CrewsRankingPage/components/RankingItem';
+
+import { Button } from '@components/shared/Button';
+import { Flex } from '@components/shared/Flex';
+import { Text } from '@components/shared/Text';
+
+import { PATH_NAME } from '@constants/pathName';
+
+import { MainPageSubContainer } from '../MainPage.style';
+
+const CrewRanking = ({
+  slicedCrewsRanking,
+  navigate,
+  MAIN_PAGE_BUTTON_PROP,
+}) => {
+  return (
+    <MainPageSubContainer>
+      <Text children={'크루 랭킹'} weight={700} size={'1.25rem'} />
+      <RankingHeader justify="space-between">
+        <Flex gap={55}>
+          <Text size={14} nowrap>
+            순위
+          </Text>
+          <Text size={14} nowrap>
+            크루 이름
+          </Text>
+        </Flex>
+        <Text size={14} nowrap>
+          점수
+        </Text>
+      </RankingHeader>
+      {slicedCrewsRanking.map((crewRank) => (
+        <RankingItem
+          key={crewRank.id}
+          rank={crewRank.rank}
+          name={crewRank.name}
+          profileImageUrl={crewRank.profileImageUrl}
+          rating={crewRank.totalScore}
+          onClick={() =>
+            navigate(PATH_NAME.GET_CREWS_PATH(String(crewRank.id)))
+          }
+        />
+      ))}
+      <Button
+        {...MAIN_PAGE_BUTTON_PROP}
+        onClick={() => navigate(PATH_NAME.CREWS_RANKING)}
+      >
+        전체 크루 랭킹 보기
+      </Button>
+    </MainPageSubContainer>
+  );
+};
+
+export default CrewRanking;

--- a/src/pages/MainPage/components/CrewRanking.tsx
+++ b/src/pages/MainPage/components/CrewRanking.tsx
@@ -1,3 +1,5 @@
+import { NavigateFunction } from 'react-router-dom';
+
 import { RankingHeader } from '@pages/CrewsRankingPage/CrewsRankingPage.styles';
 import { RankingItem } from '@pages/CrewsRankingPage/components/RankingItem';
 
@@ -5,14 +7,21 @@ import { Button } from '@components/shared/Button';
 import { Flex } from '@components/shared/Flex';
 import { Text } from '@components/shared/Text';
 
+import { CrewRank } from '@type/models/CrewRank';
+
 import { PATH_NAME } from '@constants/pathName';
 
+import { MAIN_PAGE_BUTTON_PROP_TYPE } from '../MainPage.style';
 import { MainPageSubContainer } from '../MainPage.style';
 
 const CrewRanking = ({
   slicedCrewsRanking,
   navigate,
   MAIN_PAGE_BUTTON_PROP,
+}: {
+  slicedCrewsRanking: CrewRank[];
+  navigate: NavigateFunction;
+  MAIN_PAGE_BUTTON_PROP: MAIN_PAGE_BUTTON_PROP_TYPE;
 }) => {
   return (
     <MainPageSubContainer>

--- a/src/pages/MainPage/components/NearGame.tsx
+++ b/src/pages/MainPage/components/NearGame.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@components/shared/Button';
+import { Text } from '@components/shared/Text';
+
+import { PATH_NAME } from '@constants/pathName';
+
+import { MainPageSubContainer } from '../MainPage.style';
+import { MainPageNoContentItem } from './MainPageNoContentItem';
+
+const NearGame = ({ filteredGameData, navigate, MAIN_PAGE_BUTTON_PROP }) => {
+  return (
+    <MainPageSubContainer>
+      <Text children={'내 근처 게스트 매치'} weight={700} size={'1.25rem'} />
+      {filteredGameData.length === 0 ? (
+        <MainPageNoContentItem
+          name={'GAME'}
+          onClick={() => navigate(PATH_NAME.CREATE_GAME)}
+        />
+      ) : (
+        filteredGameData
+      )}
+      {filteredGameData.length === 0 || filteredGameData.length === 1 ? (
+        <Button
+          {...MAIN_PAGE_BUTTON_PROP}
+          onClick={() => navigate(PATH_NAME.MAP)}
+        >
+          다른 지역 게스트 매치 보러가기
+        </Button>
+      ) : (
+        <Button
+          {...MAIN_PAGE_BUTTON_PROP}
+          onClick={() => navigate(PATH_NAME.GAMES_NEAR)}
+        >
+          더보기
+        </Button>
+      )}
+    </MainPageSubContainer>
+  );
+};
+
+export default NearGame;

--- a/src/pages/MainPage/components/NearGame.tsx
+++ b/src/pages/MainPage/components/NearGame.tsx
@@ -1,12 +1,27 @@
+import { NavigateFunction } from 'react-router-dom';
+
+import { EmotionJSX } from 'node_modules/@emotion/react/types/jsx-namespace';
+
 import { Button } from '@components/shared/Button';
 import { Text } from '@components/shared/Text';
 
 import { PATH_NAME } from '@constants/pathName';
 
-import { MainPageSubContainer } from '../MainPage.style';
+import {
+  MAIN_PAGE_BUTTON_PROP_TYPE,
+  MainPageSubContainer,
+} from '../MainPage.style';
 import { MainPageNoContentItem } from './MainPageNoContentItem';
 
-const NearGame = ({ filteredGameData, navigate, MAIN_PAGE_BUTTON_PROP }) => {
+const NearGame = ({
+  filteredGameData,
+  navigate,
+  MAIN_PAGE_BUTTON_PROP,
+}: {
+  filteredGameData: EmotionJSX.Element[];
+  navigate: NavigateFunction;
+  MAIN_PAGE_BUTTON_PROP: MAIN_PAGE_BUTTON_PROP_TYPE;
+}) => {
   return (
     <MainPageSubContainer>
       <Text children={'내 근처 게스트 매치'} weight={700} size={'1.25rem'} />

--- a/src/pages/MainPage/components/RecommendCrew.tsx
+++ b/src/pages/MainPage/components/RecommendCrew.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@components/shared/Button';
+import { Text } from '@components/shared/Text';
+
+import { PATH_NAME } from '@constants/pathName';
+
+import { MainPageSubContainer } from '../MainPage.style';
+import { MainPageNoContentItem } from './MainPageNoContentItem';
+
+const RecommendCrew = ({
+  filteredCrewData,
+  navigate,
+  MAIN_PAGE_BUTTON_PROP,
+}) => {
+  return (
+    <MainPageSubContainer>
+      <Text children={'추천 크루'} weight={700} size={'1.25rem'} />
+      {filteredCrewData.length === 0 ? (
+        <MainPageNoContentItem
+          name={'CREW'}
+          onClick={() => navigate(PATH_NAME.CREATE_CREW)}
+        />
+      ) : (
+        filteredCrewData
+      )}
+      {filteredCrewData.length !== 0 && (
+        <Button
+          {...MAIN_PAGE_BUTTON_PROP}
+          onClick={() => navigate(PATH_NAME.CREWS_RECOMMEND)}
+        >
+          더보기
+        </Button>
+      )}
+    </MainPageSubContainer>
+  );
+};
+
+export default RecommendCrew;

--- a/src/pages/MainPage/components/RecommendCrew.tsx
+++ b/src/pages/MainPage/components/RecommendCrew.tsx
@@ -1,8 +1,13 @@
+import { NavigateFunction } from 'react-router-dom';
+
+import { EmotionJSX } from 'node_modules/@emotion/react/types/jsx-namespace';
+
 import { Button } from '@components/shared/Button';
 import { Text } from '@components/shared/Text';
 
 import { PATH_NAME } from '@constants/pathName';
 
+import { MAIN_PAGE_BUTTON_PROP_TYPE } from '../MainPage.style';
 import { MainPageSubContainer } from '../MainPage.style';
 import { MainPageNoContentItem } from './MainPageNoContentItem';
 
@@ -10,6 +15,10 @@ const RecommendCrew = ({
   filteredCrewData,
   navigate,
   MAIN_PAGE_BUTTON_PROP,
+}: {
+  filteredCrewData: EmotionJSX.Element[];
+  navigate: NavigateFunction;
+  MAIN_PAGE_BUTTON_PROP: MAIN_PAGE_BUTTON_PROP_TYPE;
 }) => {
   return (
     <MainPageSubContainer>


### PR DESCRIPTION
기존 페이지 요소를 3개의 구획으로 분리
추후에 구획들에 대한 추상화가 필요하면 진행 예정

[refactor: MainPage 추상화](https://github.com/1eecan/pickple-front-refactoring/commit/829bab9f85d0ffc971944a351e63c3cbdc830df1) 

[refactor: MainPage에서 쓰이는 style prop MainPage.style.ts로 이동](https://github.com/1eecan/pickple-front-refactoring/commit/671ea3b4fecb28cc5fc4b880b7ab7f3df0f9d3c0)

[refactor: MainPage component 매개변수 타입지정](https://github.com/1eecan/pickple-front-refactoring/commit/d9c5ca8a720449a8fe14b6465f057a6432d9ab90) 
